### PR TITLE
Removed unnecessary rimraf dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "eslint": "~1.7.3",
     "eslint-config-vgno": "~4.0.1",
     "mocha": "~2.3.3",
-    "npm-check-updates": "~2.3.4",
-    "rimraf": "~2.4.3"
+    "npm-check-updates": "~2.3.4"
   },
   "roc": "1.0.0-alpha4",
   "author": "VG",


### PR DESCRIPTION
No point in having `rimraf` in both dev and normal dependencies.