### PR TITLE
Extra assets using config

### DIFF
--- a/src/roc/builder/index.js
+++ b/src/roc/builder/index.js
@@ -79,9 +79,9 @@ export default function createBuilder(target, resolver = 'roc-web/lib/helpers/ge
     }
 
     if (CLIENT) {
-        const makeAllPathsGlobal = (input) => input.map((elem) => getAbsolutePath(elem));
+        const makeAllPathsAbsolute = (input) => input.map((elem) => getAbsolutePath(elem));
 
-        const assets = makeAllPathsGlobal(config.build.assets);
+        const assets = makeAllPathsAbsolute(config.build.assets);
         webpackConfig.entry[config.build.outputName] = webpackConfig.entry[config.build.outputName].concat(assets);
     }
 

--- a/src/roc/config/roc.config.js
+++ b/src/roc/config/roc.config.js
@@ -31,6 +31,7 @@ const config = {
     },
 
     build: {
+        assets: [],
         verbose: true,
         mode: 'dist',
         target: ['client', 'server'],

--- a/src/roc/config/roc.config.meta.js
+++ b/src/roc/config/roc.config.meta.js
@@ -1,4 +1,11 @@
-import { isInteger, isString, isBoolean, isPath, isArray, isArrayOrSingle } from 'roc-config/validators';
+import {
+    isInteger,
+    isString,
+    isBoolean,
+    isPath,
+    isArray,
+    isArrayOrSingle
+} from 'roc-config/validators';
 
 const configMeta = {
     descriptions: {
@@ -29,6 +36,7 @@ const configMeta = {
         },
 
         build: {
+            assets: 'An array of files to include into the build process',
             verbose: 'If verbose mode should be used, returns more output during build',
             mode: 'What mode the application should be built for. Possible values are "dev", "dist" and "test"',
             target: 'For what target the application should be built for. Possible values are "client" and "server"',
@@ -74,6 +82,7 @@ const configMeta = {
         },
 
         build: {
+            assets: isArray(isPath),
             verbose: isBoolean,
             mode: /^dev|dist|test$/i,
             target: isArray(/^client|server$/i),


### PR DESCRIPTION
Made it possible to include extra assets using config.

Use by defining a `build.assets` array in the configuration. Can be used to include external Scss mainly.

Depends on https://github.com/vgno/roc-config/pull/8 for validation to work properly.