### PR TITLE
Enable the ability to disable progressbar on builds

### DIFF
--- a/src/roc/config/roc.config.js
+++ b/src/roc/config/roc.config.js
@@ -35,6 +35,7 @@ const config = {
         verbose: true,
         mode: 'dist',
         target: ['client', 'server'],
+        disableProgressbar: false,
         entry: { client: 'src/client/index.js', server: 'src/server/index.js'},
         outputName: 'app',
         outputPath: { client: 'build/client', server: 'build/server'},

--- a/src/roc/config/roc.config.meta.js
+++ b/src/roc/config/roc.config.meta.js
@@ -40,6 +40,7 @@ const configMeta = {
             verbose: 'If verbose mode should be used, returns more output during build',
             mode: 'What mode the application should be built for. Possible values are "dev", "dist" and "test"',
             target: 'For what target the application should be built for. Possible values are "client" and "server"',
+            disableProgressbar: 'Should the progress bar be disabled for builds',
             entry: {
                 client: 'The client entry point file',
                 server: 'The server entry point file'

--- a/src/roc/config/roc.config.meta.js
+++ b/src/roc/config/roc.config.meta.js
@@ -91,6 +91,7 @@ const configMeta = {
             verbose: isBoolean,
             mode: /^dev|dist|test$/i,
             target: isArray(/^client|server$/i),
+            disableProgressbar: isBoolean,
             entry: {
                 client: isPath,
                 server: isPath

--- a/src/roc/helpers/run-build.js
+++ b/src/roc/helpers/run-build.js
@@ -54,21 +54,24 @@ const build = (createBuilder, target, config, verbose) => {
                 const { buildConfig, builder } = createBuilder(target);
 
                 const compiler = builder(buildConfig);
-                const bar = multi.newBar(`Building ${target} [:bar] :percent :elapsed s :webpackInfo`, {
-                    complete: '=',
-                    incomplete: ' ',
-                    total: 100,
-                    // Some "magic" math to make sure that the progress bar fits in the terminal window
-                    // Based on the lenght of varius strings used in the output
-                    width: (process.stdout.columns - 52)
-                });
 
-                compiler.apply(new builder.ProgressPlugin(function(percentage, msg) {
-                    bar.update(percentage, {
-                        // Only use 20 characters for output to make sure it fits in the window
-                        webpackInfo: msg.substring(0, 20)
+                if (!config.build.disableProgressbar) {
+                    const bar = multi.newBar(`Building ${target} [:bar] :percent :elapsed s :webpackInfo`, {
+                        complete: '=',
+                        incomplete: ' ',
+                        total: 100,
+                        // Some "magic" math to make sure that the progress bar fits in the terminal window
+                        // Based on the lenght of varius strings used in the output
+                        width: (process.stdout.columns - 52)
                     });
-                }));
+
+                    compiler.apply(new builder.ProgressPlugin(function(percentage, msg) {
+                        bar.update(percentage, {
+                            // Only use 20 characters for output to make sure it fits in the window
+                            webpackInfo: msg.substring(0, 20)
+                        });
+                    }));
+                }
 
                 compiler.run((error, stats) => {
                     if (error) {


### PR DESCRIPTION
When building within docker environments we need the ability to disable displaying progressbars.